### PR TITLE
Improvements to Flow Conservation Constraints

### DIFF
--- a/src/core/base.jl
+++ b/src/core/base.jl
@@ -251,6 +251,29 @@ function build_ref(data::Dict{String,<:Any})
         ref[:pipes_ne] = filter(is_ne_link, ref[:pipes])
         ref[:links_ne] = filter(is_ne_link, ref[:links])
 
+        ref[:arcs_fr] = [(i,comp["f_id"],comp["t_id"]) for (i,comp) in ref[:links]]
+        #ref[:arcs_to]   = [(i,comp["t_id"],comp["f_id"]) for (i,comp) in ref[:links]]
+        #ref[:arcs] = [ref[:arcs_fr]; ref[:arcs_to]]
+
+        #node_arcs = Dict((i, Tuple{Int,Int,Int}[]) for (i,node) in ref[:nodes])
+        #for (l,i,j) in ref[:arcs]
+        #    push!(node_arcs[i], (l,i,j))
+        #end
+        #ref[:node_arcs] = node_arcs
+
+        node_arcs_fr = Dict((i, Tuple{Int,Int,Int}[]) for (i,node) in ref[:nodes])
+        for (l,i,j) in ref[:arcs_fr]
+            push!(node_arcs_fr[i], (l,i,j))
+        end
+        ref[:node_arcs_fr] = node_arcs_fr
+
+        node_arcs_to = Dict((i, Tuple{Int,Int,Int}[]) for (i,node) in ref[:nodes])
+        for (l,i,j) in ref[:arcs_fr]
+            push!(node_arcs_to[j], (l,i,j))
+        end
+        ref[:node_arcs_to] = node_arcs_to
+
+
         #ref[:nodes] = merge(ref[:junctions], ref[:tanks], ref[:reservoirs])
         node_junctions = Dict((i, Int[]) for (i,node) in ref[:nodes])
         for (i, junction) in ref[:junctions]

--- a/src/core/constraint.jl
+++ b/src/core/constraint.jl
@@ -12,13 +12,13 @@ function constraint_undirected_flow_conservation(wm::GenericWaterModel, i::Int, 
     flow_sum = JuMP.AffExpr(0.0)
 
     # Add all incoming flow to node i.
-    for (a, link) in filter(is_in_node(i), ref(wm, n, :links))
-        JuMP.add_to_expression!(flow_sum, var(wm, n, :q, a))
+    for (l,f,t) in ref(wm, n, :node_arcs_fr, i)
+        JuMP.add_to_expression!(flow_sum, -var(wm, n, :q, l))
     end
 
     # Subtract all outgoing flow from node i.
-    for (a, link) in filter(is_out_node(i), ref(wm, n, :links))
-        JuMP.add_to_expression!(flow_sum, -var(wm, n, :q, a))
+    for (l,f,t) in ref(wm, n, :node_arcs_to, i)
+        JuMP.add_to_expression!(flow_sum, var(wm, n, :q, l))
     end
 
     for rid in ref(wm, n, :node_reservoirs, i)
@@ -51,15 +51,17 @@ function constraint_directed_flow_conservation(wm::GenericWaterModel, i::Int, n:
     flow_sum = JuMP.AffExpr(0.0)
 
     # Add all incoming flow to node i.
-    for (a, conn) in filter(is_in_node(i), ref(wm, n, :links))
-        JuMP.add_to_expression!(flow_sum, var(wm, n, :qp, a))
-        JuMP.add_to_expression!(flow_sum, -var(wm, n, :qn, a))
+    #println(ref(wm, n, :node_arcs_fr, i))
+    for (l,f,t) in ref(wm, n, :node_arcs_fr, i)
+        JuMP.add_to_expression!(flow_sum, -var(wm, n, :qp, l))
+        JuMP.add_to_expression!(flow_sum, var(wm, n, :qn, l))
     end
 
     # Subtract all outgoing flow from node i.
-    for (a, conn) in filter(is_out_node(i), ref(wm, n, :links))
-        JuMP.add_to_expression!(flow_sum, -var(wm, n, :qp, a))
-        JuMP.add_to_expression!(flow_sum, var(wm, n, :qn, a))
+    #println(ref(wm, n, :node_arcs_to, i))
+    for (l,f,t) in ref(wm, n, :node_arcs_to, i)
+        JuMP.add_to_expression!(flow_sum, var(wm, n, :qp, l))
+        JuMP.add_to_expression!(flow_sum, -var(wm, n, :qn, l))
     end
 
     for rid in ref(wm, n, :node_reservoirs, i)


### PR DESCRIPTION
This makes the build time for flow conservation constraints linear from quadratic.  It also replaces the `flow_sum` expression with a simple JuMP constraint.