### PR TITLE
Fixes for InfrastructureModels.print_summary

### DIFF
--- a/src/core/ref.jl
+++ b/src/core/ref.jl
@@ -172,8 +172,7 @@ function calc_tank_volume_bounds(wm::GenericWaterModel, n::Int=wm.cnw)
     ub = Dict{Int64, Float64}(i => Inf for i in ids(wm, n, :tanks))
 
     for (i, tank) in ref(wm, n, :tanks)
-        # TODO: Change this after we drop nothing entries from dictionaries.
-        if tank["curve_name"] == nothing
+        if !("curve_name" in keys(tank))
             surface_area = 0.25 * pi * tank["diameter"]^2
             lb[i] = min(tank["min_vol"], surface_area * tank["min_level"])
             ub[i] = surface_area * tank["max_level"]

--- a/src/io/epanet.jl
+++ b/src/io/epanet.jl
@@ -417,13 +417,6 @@ function _clean_nothing!(data)
     return data
 end
 
-#def clean_empty(d):
-#    if not isinstance(d, (dict, list)):
-#        return d
-#    if isinstance(d, list):
-#        return [v for v in (clean_empty(v) for v in d) if v]
-#    return {k: v for k, v in ((k, clean_empty(v)) for k, v in d.items()) if v}
-
 """
     parse_epanet(path)
 


### PR DESCRIPTION
This allows the data to be properly printed using `InfrastructureModels.print_summary`. However, this would break if, for example, data["options"] were of type `Dict` instead of `DataStructures.OrderedDict`. @ccoffrin, how should non-component `Dict` entries be handled? Is this a problem with the WaterModels data model or with how InfrastructureModels parses this data in `print_summary`?