### PR TITLE
retain source_id for junction-nodes without demand

### DIFF
--- a/src/io/epanet.jl
+++ b/src/io/epanet.jl
@@ -211,6 +211,9 @@ function epanet_to_watermodels!(data::Dict{String,<:Any}; import_all::Bool = fal
 
     for (i, junction) in data["junction"]
         if isapprox(junction["demand"], 0.0, atol=1.0e-7)
+            # copy source_id to the corresponding node before deleting the junction
+            nodekey = string(junction["node"])
+            data["node"][nodekey]["source_id"] = junction["source_id"]
             delete!(data["junction"], i)
             haskey(data, "time_series") && delete!(data["time_series"]["junction"], i)
         end


### PR DESCRIPTION
copy the junction's source_id over to the corresponding node if the junction is deleted because of no demand