### PR TITLE
FIX: Ensure short pipes with valves are reduced to just valves

### DIFF
--- a/src/io/epanet.jl
+++ b/src/io/epanet.jl
@@ -1151,10 +1151,10 @@ internal WaterModels use. Imports all data from the EPANET file if `import_all` 
 """
 function epanet_to_watermodels!(data::Dict{String,<:Any}; import_all::Bool = false)
     _drop_zero_demands!(data) # Drop demands of zero from nodes.
+    _convert_short_pipes!(data) # Convert pipes that are short to short pipes and valves.
     _add_valves_to_tanks!(data) # Ensure that shutoff valves are connected to tanks.
     _add_valves_from_pipes!(data) # Convert pipes with valves to pipes *and* valves.
     _drop_pipe_flags!(data) # Drop irrelevant pipe attributes.
-    _convert_pipes_to_short_pipes!(data) # Convert pipes that are short to short pipes.
 end
 
 
@@ -1174,17 +1174,30 @@ function _get_max_node_id(data::Dict{String,<:Any})
 end
 
 
-function _convert_pipes_to_short_pipes!(data::Dict{String,<:Any})
+function _convert_short_pipes!(data::Dict{String,<:Any})
     res = calc_resistances(data["pipe"], data["viscosity"], data["head_loss"])
     res = Dict{String,Any}(a => res[a] .* x["length"] for (a, x) in data["pipe"])
-    short_pipe_indices = [a for (a, r) in res if all(r .<= 0.01)]
+    pipe_indices = [a for (a, r) in res if all(r .<= 0.01)] # Pipes with small resistances.
 
-    for a in short_pipe_indices
-        short_pipe = deepcopy(data["pipe"][a])
-        delete!(short_pipe, "diameter")
-        delete!(short_pipe, "length")
-        delete!(short_pipe, "roughness")
-        data["short_pipe"][a] = short_pipe
+    for a in pipe_indices
+        pipe = deepcopy(data["pipe"][a])
+
+        # Delete unnecessary fields.
+        delete!(pipe, "diameter")
+        delete!(pipe, "length")
+        delete!(pipe, "roughness")
+
+        if pipe["has_valve"]
+            # Transform the pipe into a valve.
+            delete!(pipe, "has_valve")
+            data["valve"][a] = pipe
+        else
+            # Transform the pipe into a short pipe.
+            delete!(pipe, "has_valve")
+            data["short_pipe"][a] = pipe
+        end
+
+        # Delete the original pipe component.
         delete!(data["pipe"], a)
     end
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -18,4 +18,14 @@
         @test isapprox(mn_data["nw"]["2"]["demand"]["2"]["flow_rate"], 0.5*0.02777, rtol=1.0e-4)
         @test isapprox(mn_data["nw"]["3"]["demand"]["2"]["flow_rate"], 0.25*0.02777, rtol=1.0e-4)
     end
+
+    @testset "epanet_to_watermodels!" begin
+        network_data = WaterModels.parse_epanet("../test/data/epanet/snapshot/short-pipe-lps.inp")
+        WaterModels.epanet_to_watermodels!(network_data)
+        @test haskey(network_data["short_pipe"], "1")
+
+        network_data = WaterModels.parse_epanet("../test/data/epanet/snapshot/short-pipe-valve-lps.inp")
+        WaterModels.epanet_to_watermodels!(network_data)
+        @test haskey(network_data["valve"], "1")
+    end
 end

--- a/test/data/epanet/snapshot/short-pipe-lps.inp
+++ b/test/data/epanet/snapshot/short-pipe-lps.inp
@@ -1,0 +1,109 @@
+[TITLE]
+Test for Hazen-Williams Head Loss
+
+[JUNCTIONS]
+;ID              Elev            Demand          Pattern
+ 2               0.0             1000.0                 ;
+
+[RESERVOIRS]
+;ID              Head            Pattern
+ 1               10.0                                   ;
+
+[TANKS]
+;ID              Elevation       InitLevel       MinLevel         MaxLevel         Diameter         MinVol           VolCurve
+
+[PIPES]
+;ID               Node1          Node2           Length           Diameter         Roughness        MinorLoss        Status
+ 1                1              2               1.0              1000.0           100.0            0.0              Open  ;
+
+[PUMPS]
+;ID               Node1          Node2           Parameters
+
+[VALVES]
+;ID               Node1          Node2           Diameter         Type             Setting          MinorLoss   
+
+[TAGS]
+
+[DEMANDS]
+;Junction         Demand         Pattern         Category
+
+[STATUS]
+;ID               Status/Setting
+
+[PATTERNS]
+;ID               Multipliers
+
+[CURVES]
+;ID               X-Value        Y-Value
+
+[CONTROLS]
+
+[RULES]
+
+[ENERGY]
+
+[EMITTERS]
+;Junction         Coefficient
+
+[QUALITY]
+;Node             InitQual
+
+[SOURCES]
+;Node             Type           Quality         Pattern
+
+[REACTIONS]
+;Type             Pipe/Tank      Coefficient
+
+[REACTIONS]
+
+[MIXING]
+;Tank             Model
+
+[TIMES]
+ Duration               0:00
+ Hydraulic Timestep     1:00
+ Quality Timestep       0:05
+ Pattern Timestep       2:00 
+ Pattern Start          0:00 
+ Report Timestep        1:00 
+ Report Start           0:00 
+ Start ClockTime        12 am
+ Statistic              NONE
+
+[REPORT]
+ Status                 Yes
+ Summary                No
+ Page                   0
+
+[OPTIONS]
+ Units                  LPS
+ Headloss               H-W
+ Specific Gravity       1.0
+ Viscosity              1.0
+ Trials                 40
+ Accuracy               0.00000001
+ Unbalanced             Continue 10
+ Pattern                1
+ Demand Multiplier      1.0
+ Emitter Exponent       0.5
+ Diffusivity            1.0
+ Tolerance              0.01
+
+[COORDINATES]
+;Node             X-Coord        Y-Coord
+ 1                0.0            2500.0
+ 2                1414.21        1085.79
+
+[VERTICES]
+;Link             X-Coord        Y-Coord
+
+[LABELS]
+;X-Coord          Y-Coord        Label & Anchor Node
+
+[BACKDROP]
+ DIMENSIONS       980.00         980.00          5000.00          5000.00         
+ UNITS            None
+ FILE
+ OFFSET           0.00           0.00
+
+[END]

--- a/test/data/epanet/snapshot/short-pipe-valve-lps.inp
+++ b/test/data/epanet/snapshot/short-pipe-valve-lps.inp
@@ -1,0 +1,109 @@
+[TITLE]
+Test for Hazen-Williams Head Loss
+
+[JUNCTIONS]
+;ID              Elev            Demand          Pattern
+ 2               0.0             1000.0                 ;
+
+[RESERVOIRS]
+;ID              Head            Pattern
+ 1               10.0                                   ;
+
+[TANKS]
+;ID              Elevation       InitLevel       MinLevel         MaxLevel         Diameter         MinVol           VolCurve
+
+[PIPES]
+;ID               Node1          Node2           Length           Diameter         Roughness        MinorLoss        Status
+ 1                1              2               1.0              1000.0           100.0            0.0              CV  ;
+
+[PUMPS]
+;ID               Node1          Node2           Parameters
+
+[VALVES]
+;ID               Node1          Node2           Diameter         Type             Setting          MinorLoss   
+
+[TAGS]
+
+[DEMANDS]
+;Junction         Demand         Pattern         Category
+
+[STATUS]
+;ID               Status/Setting
+
+[PATTERNS]
+;ID               Multipliers
+
+[CURVES]
+;ID               X-Value        Y-Value
+
+[CONTROLS]
+
+[RULES]
+
+[ENERGY]
+
+[EMITTERS]
+;Junction         Coefficient
+
+[QUALITY]
+;Node             InitQual
+
+[SOURCES]
+;Node             Type           Quality         Pattern
+
+[REACTIONS]
+;Type             Pipe/Tank      Coefficient
+
+[REACTIONS]
+
+[MIXING]
+;Tank             Model
+
+[TIMES]
+ Duration               0:00
+ Hydraulic Timestep     1:00
+ Quality Timestep       0:05
+ Pattern Timestep       2:00 
+ Pattern Start          0:00 
+ Report Timestep        1:00 
+ Report Start           0:00 
+ Start ClockTime        12 am
+ Statistic              NONE
+
+[REPORT]
+ Status                 Yes
+ Summary                No
+ Page                   0
+
+[OPTIONS]
+ Units                  LPS
+ Headloss               H-W
+ Specific Gravity       1.0
+ Viscosity              1.0
+ Trials                 40
+ Accuracy               0.00000001
+ Unbalanced             Continue 10
+ Pattern                1
+ Demand Multiplier      1.0
+ Emitter Exponent       0.5
+ Diffusivity            1.0
+ Tolerance              0.01
+
+[COORDINATES]
+;Node             X-Coord        Y-Coord
+ 1                0.0            2500.0
+ 2                1414.21        1085.79
+
+[VERTICES]
+;Link             X-Coord        Y-Coord
+
+[LABELS]
+;X-Coord          Y-Coord        Label & Anchor Node
+
+[BACKDROP]
+ DIMENSIONS       980.00         980.00          5000.00          5000.00         
+ UNITS            None
+ FILE
+ OFFSET           0.00           0.00
+
+[END]


### PR DESCRIPTION
@jjstickel, assuming this corrects the issue we were discussing, this should close #112. It doesn't ensure that *all* short pipes don't have adjacent valves, but it does ensure that when parsing EPANET files, we will not decompose a short-enough pipe with a valve into a short pipe *and* a valve.

If we want to pursue a more careful reduction of the network (e.g., ensure short pipes and valves never exist in sequence), I think this would be more easily facilitated by using a package that inspects the graph structure of the network (e.g., LightGraphs.jl).