### PR TITLE
add per_unit keyword with io

### DIFF
--- a/src/io/common.jl
+++ b/src/io/common.jl
@@ -5,7 +5,7 @@ Parses an [EPANET](https://www.epa.gov/water-research/epanet) (.inp) or JavaScri
 Notation (JSON) file from the file path `path`, depending on the file extension, and returns
 a WaterModels data structure (a dictionary of data).
 """
-function parse_file(path::String; skip_correct::Bool = false)
+function parse_file(path::String; skip_correct::Bool = false, per_unit = true)
     if endswith(path, ".inp")
         network_data = WaterModels.parse_epanet(path)
     elseif endswith(path, ".json")
@@ -20,7 +20,7 @@ function parse_file(path::String; skip_correct::Bool = false)
     end
 
     if !skip_correct
-        correct_network_data!(network_data)
+        correct_network_data!(network_data; per_unit)
     end
 
     return network_data
@@ -51,7 +51,7 @@ function _read_file_as_string(file_path::String)
 end
 
 
-function correct_network_data!(data::Dict{String, <:Any})
+function correct_network_data!(data::Dict{String, <:Any}; per_unit=true)
     epanet_to_watermodels!(data; import_all = false)
     correct_pipes!(data)
     correct_des_pipes!(data)
@@ -61,6 +61,8 @@ function correct_network_data!(data::Dict{String, <:Any})
     correct_valves!(data)
     correct_nodes!(data)
 
-    # Make data per-unit if necessary.
-    make_per_unit!(data)
+    if per_unit
+        # Make data per-unit if necessary.
+        make_per_unit!(data)
+    end
 end


### PR DESCRIPTION
This small change enables the network to be read in without setting the network to `per_unit = true`. It is useful for creating visualizations. 